### PR TITLE
Port server to async

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 miniserve = { path = "../miniserve" }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.121"
+tokio = { workspace = true, features = ["full"] }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,7 +1,7 @@
 use miniserve::{http::StatusCode, Content, Request, Response};
 use serde::{Deserialize, Serialize};
 
-fn index(_req: Request) -> Response {
+async fn index(_req: Request) -> Response {
     let content = include_str!("../index.html").to_string();
     Ok(Content::Html(content))
 }
@@ -11,7 +11,7 @@ struct Messages {
     messages: Vec<String>,
 }
 
-fn chat(req: Request) -> Response {
+async fn chat(req: Request) -> Response {
     let Request::Post(body) = req else {
         return Err(StatusCode::METHOD_NOT_ALLOWED);
     };
@@ -24,9 +24,11 @@ fn chat(req: Request) -> Response {
     Ok(Content::Json(serde_json::to_string(&messages).unwrap()))
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     miniserve::Server::new()
         .route("/", index)
         .route("/chat", chat)
         .run()
+        .await
 }


### PR DESCRIPTION
Reference solution for porting the `server` crate to use the async feature. Key pieces:
- Add `async` keyword to each handler and the `main` function
- Add `#[tokio::main]` annotation to the async `main`
- Add tokio as a dependency of `server`